### PR TITLE
Improve error handling in _build_lookup_table entry points

### DIFF
--- a/nbdev/doclinks.py
+++ b/nbdev/doclinks.py
@@ -210,8 +210,11 @@ def _build_lookup_table(strip_libs=None, incl_libs=None, skip_mods=None):
     skip_mods = setify(skip_mods)
     strip_libs = L(strip_libs)
     if incl_libs is not None: incl_libs = (L(incl_libs)+strip_libs).unique()
-    entries = {o.name: _qual_syms(o.resolve()) for o in list(pkg_resources.iter_entry_points(group='nbdev'))
-               if incl_libs is None or o.dist.key in incl_libs}
+    entries = {}
+    for o in pkg_resources.iter_entry_points(group='nbdev'):
+        if incl_libs is not None and o.dist.key not in incl_libs: continue
+        try: entries[o.name] = _qual_syms(o.resolve())
+        except Exception: pass
     py_syms = merge(*L(o['syms'].values() for o in entries.values()).concat())
     for m in strip_libs:
         if m in entries:

--- a/nbs/api/05_doclinks.ipynb
+++ b/nbs/api/05_doclinks.ipynb
@@ -534,8 +534,11 @@
     "    skip_mods = setify(skip_mods)\n",
     "    strip_libs = L(strip_libs)\n",
     "    if incl_libs is not None: incl_libs = (L(incl_libs)+strip_libs).unique()\n",
-    "    entries = {o.name: _qual_syms(o.resolve()) for o in list(pkg_resources.iter_entry_points(group='nbdev'))\n",
-    "               if incl_libs is None or o.dist.key in incl_libs}\n",
+    "    entries = {}\n",
+    "    for o in pkg_resources.iter_entry_points(group='nbdev'):\n",
+    "        if incl_libs is not None and o.dist.key not in incl_libs: continue\n",
+    "        try: entries[o.name] = _qual_syms(o.resolve())\n",
+    "        except Exception: pass\n",
     "    py_syms = merge(*L(o['syms'].values() for o in entries.values()).concat())\n",
     "    for m in strip_libs:\n",
     "        if m in entries:\n",
@@ -545,6 +548,85 @@
     "                        for k,v in dets.items()}\n",
     "            py_syms = merge(stripped, py_syms)\n",
     "    return entries,py_syms"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "#|hide\n",
+    "_build_lookup_table.cache_clear()\n",
+    "\n",
+    "# Test _build_lookup_table caching\n",
+    "initial = _build_lookup_table.cache_info()\n",
+    "_ = _build_lookup_table()  # First call should miss\n",
+    "after_first = _build_lookup_table.cache_info()\n",
+    "_ = _build_lookup_table()  # Second call should hit\n",
+    "after_second = _build_lookup_table.cache_info()\n",
+    "\n",
+    "test_eq(after_first.misses, initial.misses + 1)\n",
+    "test_eq(after_first.hits, initial.hits)\n",
+    "test_eq(after_second.hits, after_first.hits + 1)\n",
+    "test_eq(after_second.misses, after_first.misses)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Let's test out our error handling when one of the entry points throws an error:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Create mock entry points\n",
+    "class BadEntryPoint:\n",
+    "    name = 'bad_entry'\n",
+    "    dist = type('Dist', (), {'key': 'bad_lib'})()\n",
+    "    def resolve(self): raise AttributeError(\"Simulated error\")\n",
+    "\n",
+    "class GoodEntryPoint:\n",
+    "    name = 'good_entry'\n",
+    "    dist = type('Dist', (), {'key': 'good_lib'})()\n",
+    "    def resolve(self): return {'syms': {}, 'settings': {}}"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "{'good_entry': {'syms': {}, 'settings': {}}}"
+      ]
+     },
+     "execution_count": null,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "from unittest.mock import patch as xpatch\n",
+    "# Clear the cache before testing\n",
+    "_build_lookup_table.cache_clear()\n",
+    "\n",
+    "# Patch iter_entry_points\n",
+    "with xpatch('pkg_resources.iter_entry_points', return_value=[BadEntryPoint(), GoodEntryPoint()]):\n",
+    "    entries, py_syms = _build_lookup_table()\n",
+    "    \n",
+    "    # Should only contain the good entry\n",
+    "    assert 'bad_entry' not in entries\n",
+    "    assert 'good_entry' in entries\n",
+    "    assert len(entries) == 1\n",
+    "entries"
    ]
   },
   {
@@ -600,37 +682,6 @@
    ]
   },
   {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "/Users/nathan/miniconda3/lib/python3.12/site-packages/tqdm/auto.py:21: TqdmWarning: IProgress not found. Please update jupyter and ipywidgets. See https://ipywidgets.readthedocs.io/en/stable/user_install.html\n",
-      "  from .autonotebook import tqdm as notebook_tqdm\n"
-     ]
-    }
-   ],
-   "source": [
-    "#|hide\n",
-    "_build_lookup_table.cache_clear()\n",
-    "\n",
-    "# Test _build_lookup_table caching\n",
-    "initial = _build_lookup_table.cache_info()\n",
-    "_ = _build_lookup_table()  # First call should miss\n",
-    "after_first = _build_lookup_table.cache_info()\n",
-    "_ = _build_lookup_table()  # Second call should hit\n",
-    "after_second = _build_lookup_table.cache_info()\n",
-    "\n",
-    "test_eq(after_first.misses, initial.misses + 1)\n",
-    "test_eq(after_first.hits, initial.hits)\n",
-    "test_eq(after_second.hits, after_first.hits + 1)\n",
-    "test_eq(after_second.misses, after_first.misses)"
-   ]
-  },
-  {
    "cell_type": "markdown",
    "metadata": {},
    "source": [
@@ -670,7 +721,7 @@
       "text/markdown": [
        "---\n",
        "\n",
-       "[source](https://github.com/fastai/nbdev/blob/master/nbdev/doclinks.py#L234){target=\"_blank\" style=\"float:right; font-size:smaller\"}\n",
+       "[source](https://github.com/fastai/nbdev/blob/master/nbdev/doclinks.py#L243){target=\"_blank\" style=\"float:right; font-size:smaller\"}\n",
        "\n",
        "### NbdevLookup.doc\n",
        "\n",
@@ -681,7 +732,7 @@
       "text/plain": [
        "---\n",
        "\n",
-       "[source](https://github.com/fastai/nbdev/blob/master/nbdev/doclinks.py#L234){target=\"_blank\" style=\"float:right; font-size:smaller\"}\n",
+       "[source](https://github.com/fastai/nbdev/blob/master/nbdev/doclinks.py#L243){target=\"_blank\" style=\"float:right; font-size:smaller\"}\n",
        "\n",
        "### NbdevLookup.doc\n",
        "\n",
@@ -697,6 +748,13 @@
    ],
    "source": [
     "show_doc(NbdevLookup.doc)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Here's a test suite that verifies the error handling behavior:"
    ]
   },
   {
@@ -765,7 +823,7 @@
       "text/markdown": [
        "---\n",
        "\n",
-       "[source](https://github.com/fastai/nbdev/blob/master/nbdev/doclinks.py#L239){target=\"_blank\" style=\"float:right; font-size:smaller\"}\n",
+       "[source](https://github.com/fastai/nbdev/blob/master/nbdev/doclinks.py#L248){target=\"_blank\" style=\"float:right; font-size:smaller\"}\n",
        "\n",
        "### NbdevLookup.code\n",
        "\n",
@@ -776,7 +834,7 @@
       "text/plain": [
        "---\n",
        "\n",
-       "[source](https://github.com/fastai/nbdev/blob/master/nbdev/doclinks.py#L239){target=\"_blank\" style=\"float:right; font-size:smaller\"}\n",
+       "[source](https://github.com/fastai/nbdev/blob/master/nbdev/doclinks.py#L248){target=\"_blank\" style=\"float:right; font-size:smaller\"}\n",
        "\n",
        "### NbdevLookup.code\n",
        "\n",
@@ -824,7 +882,7 @@
       "text/markdown": [
        "---\n",
        "\n",
-       "[source](https://github.com/fastai/nbdev/blob/master/nbdev/doclinks.py#L257){target=\"_blank\" style=\"float:right; font-size:smaller\"}\n",
+       "[source](https://github.com/fastai/nbdev/blob/master/nbdev/doclinks.py#L266){target=\"_blank\" style=\"float:right; font-size:smaller\"}\n",
        "\n",
        "### NbdevLookup.linkify\n",
        "\n",
@@ -833,7 +891,7 @@
       "text/plain": [
        "---\n",
        "\n",
-       "[source](https://github.com/fastai/nbdev/blob/master/nbdev/doclinks.py#L257){target=\"_blank\" style=\"float:right; font-size:smaller\"}\n",
+       "[source](https://github.com/fastai/nbdev/blob/master/nbdev/doclinks.py#L266){target=\"_blank\" style=\"float:right; font-size:smaller\"}\n",
        "\n",
        "### NbdevLookup.linkify\n",
        "\n",

--- a/nbs/api/05_doclinks.ipynb
+++ b/nbs/api/05_doclinks.ipynb
@@ -52,6 +52,7 @@
    "source": [
     "#|hide\n",
     "from IPython.display import Markdown,display\n",
+    "from unittest.mock import patch as xpatch\n",
     "from fastcore.test import *\n",
     "from pdb import set_trace\n",
     "from importlib import reload\n",
@@ -614,7 +615,6 @@
     }
    ],
    "source": [
-    "from unittest.mock import patch as xpatch\n",
     "# Clear the cache before testing\n",
     "_build_lookup_table.cache_clear()\n",
     "\n",
@@ -721,7 +721,7 @@
       "text/markdown": [
        "---\n",
        "\n",
-       "[source](https://github.com/fastai/nbdev/blob/master/nbdev/doclinks.py#L243){target=\"_blank\" style=\"float:right; font-size:smaller\"}\n",
+       "[source](https://github.com/fastai/nbdev/blob/master/nbdev/doclinks.py#L241){target=\"_blank\" style=\"float:right; font-size:smaller\"}\n",
        "\n",
        "### NbdevLookup.doc\n",
        "\n",
@@ -732,7 +732,7 @@
       "text/plain": [
        "---\n",
        "\n",
-       "[source](https://github.com/fastai/nbdev/blob/master/nbdev/doclinks.py#L243){target=\"_blank\" style=\"float:right; font-size:smaller\"}\n",
+       "[source](https://github.com/fastai/nbdev/blob/master/nbdev/doclinks.py#L241){target=\"_blank\" style=\"float:right; font-size:smaller\"}\n",
        "\n",
        "### NbdevLookup.doc\n",
        "\n",
@@ -823,7 +823,7 @@
       "text/markdown": [
        "---\n",
        "\n",
-       "[source](https://github.com/fastai/nbdev/blob/master/nbdev/doclinks.py#L248){target=\"_blank\" style=\"float:right; font-size:smaller\"}\n",
+       "[source](https://github.com/fastai/nbdev/blob/master/nbdev/doclinks.py#L246){target=\"_blank\" style=\"float:right; font-size:smaller\"}\n",
        "\n",
        "### NbdevLookup.code\n",
        "\n",
@@ -834,7 +834,7 @@
       "text/plain": [
        "---\n",
        "\n",
-       "[source](https://github.com/fastai/nbdev/blob/master/nbdev/doclinks.py#L248){target=\"_blank\" style=\"float:right; font-size:smaller\"}\n",
+       "[source](https://github.com/fastai/nbdev/blob/master/nbdev/doclinks.py#L246){target=\"_blank\" style=\"float:right; font-size:smaller\"}\n",
        "\n",
        "### NbdevLookup.code\n",
        "\n",
@@ -882,7 +882,7 @@
       "text/markdown": [
        "---\n",
        "\n",
-       "[source](https://github.com/fastai/nbdev/blob/master/nbdev/doclinks.py#L266){target=\"_blank\" style=\"float:right; font-size:smaller\"}\n",
+       "[source](https://github.com/fastai/nbdev/blob/master/nbdev/doclinks.py#L264){target=\"_blank\" style=\"float:right; font-size:smaller\"}\n",
        "\n",
        "### NbdevLookup.linkify\n",
        "\n",
@@ -891,7 +891,7 @@
       "text/plain": [
        "---\n",
        "\n",
-       "[source](https://github.com/fastai/nbdev/blob/master/nbdev/doclinks.py#L266){target=\"_blank\" style=\"float:right; font-size:smaller\"}\n",
+       "[source](https://github.com/fastai/nbdev/blob/master/nbdev/doclinks.py#L264){target=\"_blank\" style=\"float:right; font-size:smaller\"}\n",
        "\n",
        "### NbdevLookup.linkify\n",
        "\n",


### PR DESCRIPTION
This PR adds error handling when attempting to resolve a particular entry point. When attempting to do this resolution, a particular library might throw an error. For example, this happens with a `testcell` throws an error due to how it attempts to look into the IPython registration of magics.

```python
entries = {}
for o in pkg_resources.iter_entry_points(group='nbdev'):
    if incl_libs is not None and o.dist.key not in incl_libs: continue
    try: entries[o.name] = _qual_syms(o.resolve())
    except Exception: pass
```

I've added tests to explicitly mock a good entry point and a bad entry point to test this new functionality:

```python
# Create mock entry points
class BadEntryPoint:
    name = 'bad_entry'
    dist = type('Dist', (), {'key': 'bad_lib'})()
    def resolve(self): raise AttributeError("Simulated error")

class GoodEntryPoint:
    name = 'good_entry'
    dist = type('Dist', (), {'key': 'good_lib'})()
    def resolve(self): return {'syms': {}, 'settings': {}}

from unittest.mock import patch as xpatch
# Clear the cache before testing
_build_lookup_table.cache_clear()

# Patch iter_entry_points
with xpatch('pkg_resources.iter_entry_points', return_value=[BadEntryPoint(), GoodEntryPoint()]):
    entries, py_syms = _build_lookup_table()
    
    # Should only contain the good entry
    assert 'bad_entry' not in entries
    assert 'good_entry' in entries
    assert len(entries) == 1
entries
```

And all tests are still passing.