### PR TITLE
Change symbols dict logic to prioritize builtins

### DIFF
--- a/nbdev/doclinks.py
+++ b/nbdev/doclinks.py
@@ -244,9 +244,12 @@ def _build_lookup_table(strip_libs=None, incl_libs=None, skip_mods=None):
     for m in strip_libs:
         if m in entries:
             _d = entries[m]
-            stripped = {remove_prefix(k,f"{mod}."):v
-                        for mod,dets in _d['syms'].items() if mod not in skip_mods
-                        for k,v in dets.items()}
+            stripped = {}
+            for mod, dets in _d['syms'].items():
+                if mod not in skip_mods:
+                    for k,v in dets.items():
+                        k = remove_prefix(k,f"{mod}.")
+                        if k not in stripped: stripped[k] = v
             py_syms = merge(stripped, py_syms)
     return entries,py_syms
 

--- a/nbs/api/05_doclinks.ipynb
+++ b/nbs/api/05_doclinks.ipynb
@@ -627,11 +627,23 @@
     "    for m in strip_libs:\n",
     "        if m in entries:\n",
     "            _d = entries[m]\n",
-    "            stripped = {remove_prefix(k,f\"{mod}.\"):v\n",
-    "                        for mod,dets in _d['syms'].items() if mod not in skip_mods\n",
-    "                        for k,v in dets.items()}\n",
+    "            stripped = {}\n",
+    "            for mod, dets in _d['syms'].items():\n",
+    "                if mod not in skip_mods:\n",
+    "                    for k,v in dets.items():\n",
+    "                        k = remove_prefix(k,f\"{mod}.\")\n",
+    "                        if k not in stripped: stripped[k] = v\n",
     "            py_syms = merge(stripped, py_syms)\n",
     "    return entries,py_syms"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "entries, syms = _build_lookup_table('nbdev_stdlib')"
    ]
   },
   {
@@ -1075,7 +1087,7 @@
     {
      "data": {
       "text/plain": [
-       "'[`str.split`](https://docs.python.org/3/library/stdtypes.html#str.split) and [`str`](https://docs.python.org/3/library/locale.html#locale.str)'"
+       "'[`str.split`](https://docs.python.org/3/library/stdtypes.html#str.split) and [`str`](https://docs.python.org/3/library/stdtypes.html#str)'"
       ]
      },
      "execution_count": null,
@@ -1087,6 +1099,83 @@
     "# ... now with stripping\n",
     "md = \"`str.split` and `str`\"\n",
     "NbdevLookup('nbdev_stdlib').linkify(md)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "When there is a conflict, the linkification will apply in the order of the stripped libraries and then by alphabetical order. For example, `enumerate` is both a builtin and a function in the threading module. However, since builtins comes first alphabetically, it will take priority"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "'[`enumerate`](https://docs.python.org/3/library/functions.html#enumerate), [`builtins.enumerate`](https://docs.python.org/3/library/functions.html#enumerate) and [`threading.enumerate`](https://docs.python.org/3/library/threading.html#threading.enumerate)'"
+      ]
+     },
+     "execution_count": null,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "md = \"`enumerate`, `builtins.enumerate` and `threading.enumerate`\"\n",
+    "NbdevLookup(('nbdev_stdlib')).linkify(md)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "We can also take the `find()` function as another instance, it exists as a standard library and in numpy. Therefore, depending on the order of stripped libraries we pass, `find()` will link to either numpy or standard library."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "'[`find()`](https://numpy.org/doc/stable/reference/generated/numpy.char.find.html#numpy.char.find)'"
+      ]
+     },
+     "execution_count": null,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "md = \"`find()`\"\n",
+    "NbdevLookup(('nbdev_numpy','nbdev_stdlib')).linkify(md)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "'[`find()`](https://docs.python.org/3/library/gettext.html#gettext.find)'"
+      ]
+     },
+     "execution_count": null,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "md = \"`find()`\"\n",
+    "NbdevLookup(('nbdev_stdlib','nbdev_numpy')).linkify(md)"
    ]
   },
   {

--- a/nbs/api/05_doclinks.ipynb
+++ b/nbs/api/05_doclinks.ipynb
@@ -643,15 +643,6 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "entries, syms = _build_lookup_table('nbdev_stdlib')"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
     "#|hide\n",
     "_build_lookup_table.cache_clear()\n",
     "\n",
@@ -816,7 +807,7 @@
       "text/markdown": [
        "---\n",
        "\n",
-       "[source](https://github.com/AnswerDotAI/nbdev/blob/master/nbdev/doclinks.py#L266){target=\"_blank\" style=\"float:right; font-size:smaller\"}\n",
+       "[source](https://github.com/AnswerDotAI/nbdev/blob/master/nbdev/doclinks.py#L269){target=\"_blank\" style=\"float:right; font-size:smaller\"}\n",
        "\n",
        "### NbdevLookup.doc\n",
        "\n",
@@ -827,7 +818,7 @@
       "text/plain": [
        "---\n",
        "\n",
-       "[source](https://github.com/AnswerDotAI/nbdev/blob/master/nbdev/doclinks.py#L266){target=\"_blank\" style=\"float:right; font-size:smaller\"}\n",
+       "[source](https://github.com/AnswerDotAI/nbdev/blob/master/nbdev/doclinks.py#L269){target=\"_blank\" style=\"float:right; font-size:smaller\"}\n",
        "\n",
        "### NbdevLookup.doc\n",
        "\n",
@@ -918,7 +909,7 @@
       "text/markdown": [
        "---\n",
        "\n",
-       "[source](https://github.com/AnswerDotAI/nbdev/blob/master/nbdev/doclinks.py#L271){target=\"_blank\" style=\"float:right; font-size:smaller\"}\n",
+       "[source](https://github.com/AnswerDotAI/nbdev/blob/master/nbdev/doclinks.py#L274){target=\"_blank\" style=\"float:right; font-size:smaller\"}\n",
        "\n",
        "### NbdevLookup.code\n",
        "\n",
@@ -929,7 +920,7 @@
       "text/plain": [
        "---\n",
        "\n",
-       "[source](https://github.com/AnswerDotAI/nbdev/blob/master/nbdev/doclinks.py#L271){target=\"_blank\" style=\"float:right; font-size:smaller\"}\n",
+       "[source](https://github.com/AnswerDotAI/nbdev/blob/master/nbdev/doclinks.py#L274){target=\"_blank\" style=\"float:right; font-size:smaller\"}\n",
        "\n",
        "### NbdevLookup.code\n",
        "\n",
@@ -977,7 +968,7 @@
       "text/markdown": [
        "---\n",
        "\n",
-       "[source](https://github.com/AnswerDotAI/nbdev/blob/master/nbdev/doclinks.py#L289){target=\"_blank\" style=\"float:right; font-size:smaller\"}\n",
+       "[source](https://github.com/AnswerDotAI/nbdev/blob/master/nbdev/doclinks.py#L292){target=\"_blank\" style=\"float:right; font-size:smaller\"}\n",
        "\n",
        "### NbdevLookup.linkify\n",
        "\n",
@@ -986,7 +977,7 @@
       "text/plain": [
        "---\n",
        "\n",
-       "[source](https://github.com/AnswerDotAI/nbdev/blob/master/nbdev/doclinks.py#L289){target=\"_blank\" style=\"float:right; font-size:smaller\"}\n",
+       "[source](https://github.com/AnswerDotAI/nbdev/blob/master/nbdev/doclinks.py#L292){target=\"_blank\" style=\"float:right; font-size:smaller\"}\n",
        "\n",
        "### NbdevLookup.linkify\n",
        "\n",


### PR DESCRIPTION
This PR updates the logic for the creation of the lookup table for the python symbols in the nbdev docs api for linkifying markdown to prioritize builtins over other standard library modules.