### PR TITLE
Better handling of cells that contain string 'nbdev_export('

### DIFF
--- a/nbdev/processors.py
+++ b/nbdev/processors.py
@@ -221,7 +221,7 @@ def _ast_contains(trees, types):
 
 def _do_eval(cell):
     if cell_lang(cell) != 'python': return
-    if not cell.source or 'nbdev_export'+'()' in cell.source: return
+    if not cell.source: return
     trees = cell.parsed_()
     if cell.cell_type != 'code' or not trees: return
     if cell.directives_.get('eval:', [''])[0].lower() == 'false': return
@@ -229,7 +229,7 @@ def _do_eval(cell):
     _show_dirs = {'export','exports','exporti','exec_doc'}
     if cell.directives_.keys() & _show_dirs: return True
     if _ast_contains(trees, (ast.Import, ast.ImportFrom)):
-        if _ast_contains(trees, (ast.Expr, ast.Assign)):
+        if _ast_contains(trees, (ast.Expr, ast.Assign)) and 'nbdev_export' not in cell.source:
             warn(f'Found cells containing imports and other code. See FAQ.\n---\n{cell.source}\n---\n')
         return True
     if _show_docs(trees): return True

--- a/nbdev/test.py
+++ b/nbdev/test.py
@@ -39,7 +39,6 @@ def test_nb(fn,  # file name of notebook to test
 
     def _no_eval(cell):
         if cell.cell_type != 'code': return True
-        if 'nbdev_export'+'(' in cell.source: return True
         direc = getattr(cell, 'directives_', {}) or {}
         if direc.get('eval:', [''])[0].lower() == 'false': return True
         return flags & direc.keys()

--- a/nbs/api/10_processors.ipynb
+++ b/nbs/api/10_processors.ipynb
@@ -683,7 +683,7 @@
     "\n",
     "def _do_eval(cell):\n",
     "    if cell_lang(cell) != 'python': return\n",
-    "    if not cell.source or 'nbdev_export'+'()' in cell.source: return\n",
+    "    if not cell.source: return\n",
     "    trees = cell.parsed_()\n",
     "    if cell.cell_type != 'code' or not trees: return\n",
     "    if cell.directives_.get('eval:', [''])[0].lower() == 'false': return\n",
@@ -691,7 +691,7 @@
     "    _show_dirs = {'export','exports','exporti','exec_doc'}\n",
     "    if cell.directives_.keys() & _show_dirs: return True\n",
     "    if _ast_contains(trees, (ast.Import, ast.ImportFrom)):\n",
-    "        if _ast_contains(trees, (ast.Expr, ast.Assign)):\n",
+    "        if _ast_contains(trees, (ast.Expr, ast.Assign)) and 'nbdev_export' not in cell.source:\n",
     "            warn(f'Found cells containing imports and other code. See FAQ.\\n---\\n{cell.source}\\n---\\n')\n",
     "        return True\n",
     "    if _show_docs(trees): return True"

--- a/nbs/api/12_test.ipynb
+++ b/nbs/api/12_test.ipynb
@@ -69,7 +69,6 @@
     "\n",
     "    def _no_eval(cell):\n",
     "        if cell.cell_type != 'code': return True\n",
-    "        if 'nbdev_export'+'(' in cell.source: return True\n",
     "        direc = getattr(cell, 'directives_', {}) or {}\n",
     "        if direc.get('eval:', [''])[0].lower() == 'false': return True\n",
     "        return flags & direc.keys()\n",


### PR DESCRIPTION
Currently, if you just happen to include string `nbdev_export(` in your code cell, the whole cell will be silently ignored by `nbdev_prepare`, `nbdev_test`, `nbdev_proc_nbs` and `nbdev_preview`. If this cell happens to contain code that is exported or rendered in docs, it would result in the corresponding command failing with hard to decipher error.

I have removed the corresponding check from the nbdev code. I am not sure we need it, but I can make a version of this pull request that handles that more gracefully by injecting monkey patching code into notebooks, something like this:
```python
k.run_cell('import nbdev\ndef noop(*args, **kw): pass\nnbdev.nbdev_export = noop')
```

I imagine the check was there to prevent infinite loops of `nbdev_prepare` calling itself, but this doesn't happen because the check is for `nbdev_export` and not for `nbdev_prepare`.