### PR TITLE
Fix llmctxissue

### DIFF
--- a/nbdev/serve.py
+++ b/nbdev/serve.py
@@ -36,7 +36,7 @@ def _is_qpy(path:Path):
 
 # %% ../nbs/api/17_serve.ipynb
 def _proc_file(s, cache, path, mtime=None):
-    skips = ('_proc', '_docs', '_site')
+    skips = ('_proc', '_docs', '_site', 'settings.ini')
     if not s.is_file() or any(o[0]=='.' or o in skips for o in s.parts): return
     d = cache/s.relative_to(path)
     if s.suffix=='.py': d = d.with_suffix('')

--- a/nbs/api/14_quarto.ipynb
+++ b/nbs/api/14_quarto.ipynb
@@ -671,21 +671,9 @@
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "Python 3 (ipykernel)",
+   "display_name": "python3",
    "language": "python",
    "name": "python3"
-  },
-  "language_info": {
-   "codemirror_mode": {
-    "name": "ipython",
-    "version": 3
-   },
-   "file_extension": ".py",
-   "mimetype": "text/x-python",
-   "name": "python",
-   "nbconvert_exporter": "python",
-   "pygments_lexer": "ipython3",
-   "version": "3.12.7"
   }
  },
  "nbformat": 4,

--- a/nbs/api/14_quarto.ipynb
+++ b/nbs/api/14_quarto.ipynb
@@ -671,9 +671,21 @@
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "python3",
+   "display_name": "Python 3 (ipykernel)",
    "language": "python",
    "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.12.7"
   }
  },
  "nbformat": 4,

--- a/nbs/api/17_serve.ipynb
+++ b/nbs/api/17_serve.ipynb
@@ -196,9 +196,21 @@
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "python3",
+   "display_name": "Python 3 (ipykernel)",
    "language": "python",
    "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.12.7"
   }
  },
  "nbformat": 4,

--- a/nbs/api/17_serve.ipynb
+++ b/nbs/api/17_serve.ipynb
@@ -86,7 +86,7 @@
    "source": [
     "#|export\n",
     "def _proc_file(s, cache, path, mtime=None):\n",
-    "    skips = ('_proc', '_docs', '_site')\n",
+    "    skips = ('_proc', '_docs', '_site', 'settings.ini')\n",
     "    if not s.is_file() or any(o[0]=='.' or o in skips for o in s.parts): return\n",
     "    d = cache/s.relative_to(path)\n",
     "    if s.suffix=='.py': d = d.with_suffix('')\n",

--- a/nbs/api/17_serve.ipynb
+++ b/nbs/api/17_serve.ipynb
@@ -196,21 +196,9 @@
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "Python 3 (ipykernel)",
+   "display_name": "python3",
    "language": "python",
    "name": "python3"
-  },
-  "language_info": {
-   "codemirror_mode": {
-    "name": "ipython",
-    "version": 3
-   },
-   "file_extension": ".py",
-   "mimetype": "text/x-python",
-   "name": "python",
-   "nbconvert_exporter": "python",
-   "pygments_lexer": "ipython3",
-   "version": "3.12.7"
   }
  },
  "nbformat": 4,


### PR DESCRIPTION
IIUC `settings.ini` can be ignored by `_proc_file` which will result it in it not getting copied to the destination directory, which is what we want to avoid because they end up in `_proc` which confuses llms-txt cli, when notebooks are in the root of the repo.