### PR TITLE
fix: update workflow paths from fastai to answerdotai

### DIFF
--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -9,5 +9,5 @@ jobs:
   deploy:
     runs-on: ubuntu-latest
     steps:
-      - uses: fastai/workflows/quarto-ghp@master
+      - uses: answerdotai/workflows/quarto-ghp@master
 #         with: {pre: 1}

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -17,7 +17,7 @@ jobs:
         version: ["3.9", "3.10", "3.11", "3.12", "3.13"]
     runs-on: ${{ matrix.os }}-latest
     steps:
-      - uses: fastai/workflows/nbdev-ci@master
+      - uses: answerdotai/workflows/nbdev-ci@master
         with:
           version: ${{ matrix.version }}
           pre: 1

--- a/nbdev/cli.py
+++ b/nbdev/cli.py
@@ -91,7 +91,7 @@ def nbdev_new(**kwargs):
     _update_repo_meta(cfg)
     path = Path()
 
-    _ORG_OR_USR,_REPOSITORY = 'fastai','nbdev-template'
+    _ORG_OR_USR,_REPOSITORY = 'answerdotai','nbdev-template'
     _TEMPLATE = f'{_ORG_OR_USR}/{_REPOSITORY}'
     template = kwargs.get('template', _TEMPLATE)
     try: org_or_usr, repo = template.split('/')

--- a/nbs/api/13_cli.ipynb
+++ b/nbs/api/13_cli.ipynb
@@ -193,7 +193,7 @@
     "    _update_repo_meta(cfg)\n",
     "    path = Path()\n",
     "\n",
-    "    _ORG_OR_USR,_REPOSITORY = 'fastai','nbdev-template'\n",
+    "    _ORG_OR_USR,_REPOSITORY = 'answerdotai','nbdev-template'\n",
     "    _TEMPLATE = f'{_ORG_OR_USR}/{_REPOSITORY}'\n",
     "    template = kwargs.get('template', _TEMPLATE)\n",
     "    try: org_or_usr, repo = template.split('/')\n",


### PR DESCRIPTION
fix: update workflow paths from fastai to answerdotai

Fixes #1495

Problem:
When using `nbdev_new` on GitHub Enterprise accounts, the initial workflow fails because it's trying to use `fastai/workflows` which now redirects to `answerdotai/workflows`. While regular GitHub accounts follow this redirect automatically, Enterprise accounts are more strict about redirects, causing the workflow to fail.

Changes:
- Updated template source in `nbdev_new` from `fastai` to `answerdotai`
- Points to nbdev-template repository which will have updated workflow paths (see answerdotai/nbdev-template#20)

Note: This fix requires both this PR and answerdotai/nbdev-template#20 to be merged to be fully effective.