### PR TITLE
Use plum dispatch

### DIFF
--- a/nbdev/showdoc.py
+++ b/nbdev/showdoc.py
@@ -7,13 +7,13 @@ from __future__ import annotations
 from .doclinks import *
 from .config import get_config
 
-from fastcore.dispatch import TypeDispatch
 from fastcore.docments import *
 from fastcore.utils import *
 
 from importlib import import_module
 import inspect, sys
 from collections import OrderedDict
+from plum import Function
 from textwrap import fill
 from types import FunctionType
 
@@ -189,7 +189,7 @@ def show_doc(sym,  # Symbol to document
     elif isinstance(renderer,str):
         p,m = renderer.rsplit('.', 1)
         renderer = getattr(import_module(p), m)
-    if isinstance(sym, TypeDispatch): pass
+    if isinstance(sym, Function): pass
     else:return renderer(sym or show_doc, name=name, title_level=title_level)
 
 # %% ../nbs/api/08_showdoc.ipynb

--- a/nbdev/showdoc.py
+++ b/nbdev/showdoc.py
@@ -190,6 +190,7 @@ def show_doc(sym,  # Symbol to document
         p,m = renderer.rsplit('.', 1)
         renderer = getattr(import_module(p), m)
     if isinstance(sym, Function): pass
+    elif isinstance_str(sym, "TypeDispatch"): pass  # use _str as TypeDispatch will be removed from fastcore
     else:return renderer(sym or show_doc, name=name, title_level=title_level)
 
 # %% ../nbs/api/08_showdoc.ipynb

--- a/nbs/api/08_showdoc.ipynb
+++ b/nbs/api/08_showdoc.ipynb
@@ -32,13 +32,13 @@
     "from nbdev.doclinks import *\n",
     "from nbdev.config import get_config\n",
     "\n",
-    "from fastcore.dispatch import TypeDispatch\n",
     "from fastcore.docments import *\n",
     "from fastcore.utils import *\n",
     "\n",
     "from importlib import import_module\n",
     "import inspect, sys\n",
     "from collections import OrderedDict\n",
+    "from plum import Function\n",
     "from textwrap import fill\n",
     "from types import FunctionType"
    ]
@@ -648,7 +648,7 @@
     "    elif isinstance(renderer,str):\n",
     "        p,m = renderer.rsplit('.', 1)\n",
     "        renderer = getattr(import_module(p), m)\n",
-    "    if isinstance(sym, TypeDispatch): pass\n",
+    "    if isinstance(sym, Function): pass\n",
     "    else:return renderer(sym or show_doc, name=name, title_level=title_level)"
    ]
   },
@@ -1334,7 +1334,7 @@
    "outputs": [],
    "source": [
     "#|hide\n",
-    "from fastcore.dispatch import typedispatch"
+    "from plum import dispatch"
    ]
   },
   {
@@ -1345,7 +1345,7 @@
    "outputs": [],
    "source": [
     "#|hide\n",
-    "@typedispatch\n",
+    "@dispatch\n",
     "def _typ_test(\n",
     "    a:list, # A list\n",
     "    b:str, # A second integer\n",
@@ -1353,7 +1353,7 @@
     "    \"Perform op\"\n",
     "    return a.extend(b)\n",
     "\n",
-    "@typedispatch\n",
+    "@dispatch\n",
     "def _typ_test(\n",
     "    a:str, # An integer\n",
     "    b:str # A str\n",
@@ -1361,7 +1361,7 @@
     "    \"Perform op\"\n",
     "    return str(a) + b\n",
     "\n",
-    "test_eq(show_doc(_typ_test), None) # show_doc ignores typedispatch at the moment"
+    "test_eq(show_doc(_typ_test), None) # show_doc ignores dispatch at the moment"
    ]
   },
   {

--- a/nbs/api/08_showdoc.ipynb
+++ b/nbs/api/08_showdoc.ipynb
@@ -649,6 +649,7 @@
     "        p,m = renderer.rsplit('.', 1)\n",
     "        renderer = getattr(import_module(p), m)\n",
     "    if isinstance(sym, Function): pass\n",
+    "    elif isinstance_str(sym, \"TypeDispatch\"): pass  # use _str as TypeDispatch will be removed from fastcore\n",
     "    else:return renderer(sym or show_doc, name=name, title_level=title_level)"
    ]
   },

--- a/settings.ini
+++ b/settings.ini
@@ -15,7 +15,7 @@ language = English
 custom_sidebar = True
 license = apache2
 status = 5
-requirements = fastcore>=1.5.27 execnb>=0.1.12 astunparse ghapi>=1.0.3 watchdog asttokens setuptools
+requirements = fastcore>=1.5.27 execnb>=0.1.12 astunparse ghapi>=1.0.3 watchdog asttokens setuptools plum-dispatch
 pip_requirements = PyYAML
 conda_requirements = pyyaml
 conda_user = fastai


### PR DESCRIPTION
Part of moving dispatch and transform from fastcore to fasttransform (see [here](https://github.com/AnswerDotAI/fasttransform/issues/3)).

This PR removes the use of `fastcore.dispatch.TypeDispatch` and replaces it with `plum.Function`.

This needs to be done before merging [the PR](https://github.com/AnswerDotAI/fastcore/pull/669) that removes dispatch and transform from fastcore. Because as long as nbdev depends on `fastcore.dispatch` removing the module will cause [fastcore's integration tests to break](https://github.com/AnswerDotAI/fastcore/actions/runs/13637679980/job/38120313432?pr=669).

Open questions:
- [ ] version bump to which version?
- [ ] changelog update?