### PR TITLE
remove warning from nbdev as pkg_resources is already deprecated

### DIFF
--- a/nbs/api/05_doclinks.ipynb
+++ b/nbs/api/05_doclinks.ipynb
@@ -22,20 +22,7 @@
    "cell_type": "code",
    "execution_count": null,
    "metadata": {},
-   "outputs": [
-    {
-     "ename": "SyntaxError",
-     "evalue": "expected 'except' or 'finally' block (doclinks.py, line 244)",
-     "output_type": "error",
-     "traceback": [
-      "Traceback \u001b[36m(most recent call last)\u001b[39m:\n",
-      "  File \u001b[92m~/git/nbdev/.venv/lib/python3.12/site-packages/IPython/core/interactiveshell.py:3672\u001b[39m in \u001b[95mrun_code\u001b[39m\n    exec(code_obj, self.user_global_ns, self.user_ns)\n",
-      "  Cell \u001b[92mIn[2]\u001b[39m\u001b[92m, line 2\u001b[39m\n    from nbdev.config import *\n",
-      "\u001b[36m  \u001b[39m\u001b[36mFile \u001b[39m\u001b[32m~/git/nbdev/nbdev/__init__.py:3\u001b[39m\n\u001b[31m    \u001b[39m\u001b[31mfrom .doclinks import nbdev_export\u001b[39m\n",
-      "  \u001b[36mFile \u001b[39m\u001b[32m~/git/nbdev/nbdev/doclinks.py:244\u001b[39m\n\u001b[31m    \u001b[39m\u001b[31mpy_syms = merge(*L(o['syms'].values() for o in entries.values()).concat())\u001b[39m\n    ^\n\u001b[31mSyntaxError\u001b[39m\u001b[31m:\u001b[39m expected 'except' or 'finally' block\n"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
     "#|export\n",
     "from nbdev.config import *\n",
@@ -65,20 +52,7 @@
    "cell_type": "code",
    "execution_count": null,
    "metadata": {},
-   "outputs": [
-    {
-     "ename": "SyntaxError",
-     "evalue": "expected 'except' or 'finally' block (doclinks.py, line 244)",
-     "output_type": "error",
-     "traceback": [
-      "Traceback \u001b[36m(most recent call last)\u001b[39m:\n",
-      "  File \u001b[92m~/git/nbdev/.venv/lib/python3.12/site-packages/IPython/core/interactiveshell.py:3672\u001b[39m in \u001b[95mrun_code\u001b[39m\n    exec(code_obj, self.user_global_ns, self.user_ns)\n",
-      "  Cell \u001b[92mIn[3]\u001b[39m\u001b[92m, line 7\u001b[39m\n    from nbdev.showdoc import show_doc\n",
-      "\u001b[36m  \u001b[39m\u001b[36mFile \u001b[39m\u001b[32m~/git/nbdev/nbdev/__init__.py:3\u001b[39m\n\u001b[31m    \u001b[39m\u001b[31mfrom .doclinks import nbdev_export\u001b[39m\n",
-      "  \u001b[36mFile \u001b[39m\u001b[32m~/git/nbdev/nbdev/doclinks.py:244\u001b[39m\n\u001b[31m    \u001b[39m\u001b[31mpy_syms = merge(*L(o['syms'].values() for o in entries.values()).concat())\u001b[39m\n    ^\n\u001b[31mSyntaxError\u001b[39m\u001b[31m:\u001b[39m expected 'except' or 'finally' block\n"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
     "#|hide\n",
     "from IPython.display import Markdown,display\n",
@@ -641,16 +615,19 @@
     "    cfg = get_config()\n",
     "    if strip_libs is None:\n",
     "        try: strip_libs = cfg.get('strip_libs', cfg.get('lib_path', 'nbdev').name).split()\n",
-    "        except FileNotFoundError: strip_libs = 'nbdev'\n",
+    "        except FileNotFoundError: strip_libs = ['nbdev']\n",
     "    skip_mods = setify(skip_mods)\n",
     "    strip_libs = L(strip_libs)\n",
     "    if incl_libs is not None: incl_libs = (L(incl_libs)+strip_libs).unique()\n",
+    "    \n",
     "    entries = {}\n",
     "    eps = importlib.metadata.entry_points()\n",
-    "    for o in eps.select(group='nbdev') if hasattr(eps, 'select') else eps.get('nbdev', []):\n",
+    "    nbdev_eps = eps.select(group='nbdev') if hasattr(eps, 'select') else eps.get('nbdev', [])\n",
+    "    for o in nbdev_eps:\n",
     "        if incl_libs is not None and o.dist.name not in incl_libs: continue\n",
     "        try: entries[o.name] = _qual_syms(o.load())\n",
     "        except Exception: pass\n",
+    "\n",
     "    py_syms = merge(*L(o['syms'].values() for o in entries.values()).concat())\n",
     "    for m in strip_libs:\n",
     "        if m in entries:\n",
@@ -662,6 +639,7 @@
     "                        k = remove_prefix(k,f\"{mod}.\")\n",
     "                        if k not in stripped: stripped[k] = v\n",
     "            py_syms = merge(stripped, py_syms)\n",
+    "            \n",
     "    return entries,py_syms"
    ]
   },
@@ -826,7 +804,7 @@
       "text/plain": [
        "('https://nbdev.fast.ai/api/doclinks.html#nbdevlookup',\n",
        " 'nbdev/doclinks.py',\n",
-       " 'https://github.com/AnswerDotAI/nbdev/blob/master/nbdev/doclinks.py')"
+       " 'https://github.com/AnswerDotAI/nbdev/blob/main/nbdev/doclinks.py')"
       ]
      },
      "execution_count": null,
@@ -849,7 +827,7 @@
       "text/markdown": [
        "---\n",
        "\n",
-       "[source](https://github.com/AnswerDotAI/nbdev/blob/master/nbdev/doclinks.py#L269){target=\"_blank\" style=\"float:right; font-size:smaller\"}\n",
+       "[source](https://github.com/AnswerDotAI/nbdev/blob/main/nbdev/doclinks.py#L276){target=\"_blank\" style=\"float:right; font-size:smaller\"}\n",
        "\n",
        "### NbdevLookup.doc\n",
        "\n",
@@ -860,7 +838,7 @@
       "text/plain": [
        "---\n",
        "\n",
-       "[source](https://github.com/AnswerDotAI/nbdev/blob/master/nbdev/doclinks.py#L269){target=\"_blank\" style=\"float:right; font-size:smaller\"}\n",
+       "[source](https://github.com/AnswerDotAI/nbdev/blob/main/nbdev/doclinks.py#L276){target=\"_blank\" style=\"float:right; font-size:smaller\"}\n",
        "\n",
        "### NbdevLookup.doc\n",
        "\n",
@@ -951,7 +929,7 @@
       "text/markdown": [
        "---\n",
        "\n",
-       "[source](https://github.com/AnswerDotAI/nbdev/blob/master/nbdev/doclinks.py#L274){target=\"_blank\" style=\"float:right; font-size:smaller\"}\n",
+       "[source](https://github.com/AnswerDotAI/nbdev/blob/main/nbdev/doclinks.py#L281){target=\"_blank\" style=\"float:right; font-size:smaller\"}\n",
        "\n",
        "### NbdevLookup.code\n",
        "\n",
@@ -962,7 +940,7 @@
       "text/plain": [
        "---\n",
        "\n",
-       "[source](https://github.com/AnswerDotAI/nbdev/blob/master/nbdev/doclinks.py#L274){target=\"_blank\" style=\"float:right; font-size:smaller\"}\n",
+       "[source](https://github.com/AnswerDotAI/nbdev/blob/main/nbdev/doclinks.py#L281){target=\"_blank\" style=\"float:right; font-size:smaller\"}\n",
        "\n",
        "### NbdevLookup.code\n",
        "\n",
@@ -988,7 +966,7 @@
     {
      "data": {
       "text/plain": [
-       "'https://github.com/AnswerDotAI/fastcore/blob/master/fastcore/net.py#LNone'"
+       "'https://github.com/AnswerDotAI/fastcore/blob/main/fastcore/net.py#LNone'"
       ]
      },
      "execution_count": null,
@@ -1010,7 +988,7 @@
       "text/markdown": [
        "---\n",
        "\n",
-       "[source](https://github.com/AnswerDotAI/nbdev/blob/master/nbdev/doclinks.py#L292){target=\"_blank\" style=\"float:right; font-size:smaller\"}\n",
+       "[source](https://github.com/AnswerDotAI/nbdev/blob/main/nbdev/doclinks.py#L299){target=\"_blank\" style=\"float:right; font-size:smaller\"}\n",
        "\n",
        "### NbdevLookup.linkify\n",
        "\n",
@@ -1019,7 +997,7 @@
       "text/plain": [
        "---\n",
        "\n",
-       "[source](https://github.com/AnswerDotAI/nbdev/blob/master/nbdev/doclinks.py#L292){target=\"_blank\" style=\"float:right; font-size:smaller\"}\n",
+       "[source](https://github.com/AnswerDotAI/nbdev/blob/main/nbdev/doclinks.py#L299){target=\"_blank\" style=\"float:right; font-size:smaller\"}\n",
        "\n",
        "### NbdevLookup.linkify\n",
        "\n",

--- a/nbs/api/05_doclinks.ipynb
+++ b/nbs/api/05_doclinks.ipynb
@@ -22,7 +22,20 @@
    "cell_type": "code",
    "execution_count": null,
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "ename": "SyntaxError",
+     "evalue": "expected 'except' or 'finally' block (doclinks.py, line 244)",
+     "output_type": "error",
+     "traceback": [
+      "Traceback \u001b[36m(most recent call last)\u001b[39m:\n",
+      "  File \u001b[92m~/git/nbdev/.venv/lib/python3.12/site-packages/IPython/core/interactiveshell.py:3672\u001b[39m in \u001b[95mrun_code\u001b[39m\n    exec(code_obj, self.user_global_ns, self.user_ns)\n",
+      "  Cell \u001b[92mIn[2]\u001b[39m\u001b[92m, line 2\u001b[39m\n    from nbdev.config import *\n",
+      "\u001b[36m  \u001b[39m\u001b[36mFile \u001b[39m\u001b[32m~/git/nbdev/nbdev/__init__.py:3\u001b[39m\n\u001b[31m    \u001b[39m\u001b[31mfrom .doclinks import nbdev_export\u001b[39m\n",
+      "  \u001b[36mFile \u001b[39m\u001b[32m~/git/nbdev/nbdev/doclinks.py:244\u001b[39m\n\u001b[31m    \u001b[39m\u001b[31mpy_syms = merge(*L(o['syms'].values() for o in entries.values()).concat())\u001b[39m\n    ^\n\u001b[31mSyntaxError\u001b[39m\u001b[31m:\u001b[39m expected 'except' or 'finally' block\n"
+     ]
+    }
+   ],
    "source": [
     "#|export\n",
     "from nbdev.config import *\n",
@@ -36,7 +49,8 @@
     "from fastcore.net import urlread\n",
     "\n",
     "import ast,builtins,contextlib\n",
-    "import pkg_resources,importlib\n",
+    "import importlib.metadata\n",
+    "import importlib.util\n",
     "\n",
     "from astunparse import unparse\n",
     "from io import BytesIO\n",
@@ -51,7 +65,20 @@
    "cell_type": "code",
    "execution_count": null,
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "ename": "SyntaxError",
+     "evalue": "expected 'except' or 'finally' block (doclinks.py, line 244)",
+     "output_type": "error",
+     "traceback": [
+      "Traceback \u001b[36m(most recent call last)\u001b[39m:\n",
+      "  File \u001b[92m~/git/nbdev/.venv/lib/python3.12/site-packages/IPython/core/interactiveshell.py:3672\u001b[39m in \u001b[95mrun_code\u001b[39m\n    exec(code_obj, self.user_global_ns, self.user_ns)\n",
+      "  Cell \u001b[92mIn[3]\u001b[39m\u001b[92m, line 7\u001b[39m\n    from nbdev.showdoc import show_doc\n",
+      "\u001b[36m  \u001b[39m\u001b[36mFile \u001b[39m\u001b[32m~/git/nbdev/nbdev/__init__.py:3\u001b[39m\n\u001b[31m    \u001b[39m\u001b[31mfrom .doclinks import nbdev_export\u001b[39m\n",
+      "  \u001b[36mFile \u001b[39m\u001b[32m~/git/nbdev/nbdev/doclinks.py:244\u001b[39m\n\u001b[31m    \u001b[39m\u001b[31mpy_syms = merge(*L(o['syms'].values() for o in entries.values()).concat())\u001b[39m\n    ^\n\u001b[31mSyntaxError\u001b[39m\u001b[31m:\u001b[39m expected 'except' or 'finally' block\n"
+     ]
+    }
+   ],
    "source": [
     "#|hide\n",
     "from IPython.display import Markdown,display\n",
@@ -619,9 +646,10 @@
     "    strip_libs = L(strip_libs)\n",
     "    if incl_libs is not None: incl_libs = (L(incl_libs)+strip_libs).unique()\n",
     "    entries = {}\n",
-    "    for o in pkg_resources.iter_entry_points(group='nbdev'):\n",
-    "        if incl_libs is not None and o.dist.key not in incl_libs: continue\n",
-    "        try: entries[o.name] = _qual_syms(o.resolve())\n",
+    "    eps = importlib.metadata.entry_points()\n",
+    "    for o in eps.select(group='nbdev') if hasattr(eps, 'select') else eps.get('nbdev', []):\n",
+    "        if incl_libs is not None and o.dist.name not in incl_libs: continue\n",
+    "        try: entries[o.name] = _qual_syms(o.load())\n",
     "        except Exception: pass\n",
     "    py_syms = merge(*L(o['syms'].values() for o in entries.values()).concat())\n",
     "    for m in strip_libs:\n",
@@ -675,13 +703,13 @@
     "# Create mock entry points\n",
     "class BadEntryPoint:\n",
     "    name = 'bad_entry'\n",
-    "    dist = type('Dist', (), {'key': 'bad_lib'})()\n",
-    "    def resolve(self): raise AttributeError(\"Simulated error\")\n",
+    "    dist = type('Dist', (), {'name': 'bad_lib'})()\n",
+    "    def load(self): raise AttributeError(\"Simulated error\")\n",
     "\n",
     "class GoodEntryPoint:\n",
     "    name = 'good_entry'\n",
-    "    dist = type('Dist', (), {'key': 'good_lib'})()\n",
-    "    def resolve(self): return {'syms': {}, 'settings': {}}"
+    "    dist = type('Dist', (), {'name': 'good_lib'})()\n",
+    "    def load(self): return {'syms': {}, 'settings': {}}"
    ]
   },
   {
@@ -704,8 +732,22 @@
     "# Clear the cache before testing\n",
     "_build_lookup_table.cache_clear()\n",
     "\n",
-    "# Patch iter_entry_points\n",
-    "with xpatch('pkg_resources.iter_entry_points', return_value=[BadEntryPoint(), GoodEntryPoint()]):\n",
+    "# Create a mock entry points object that supports both access patterns\n",
+    "class MockEntryPoints:\n",
+    "    def __init__(self, entries):\n",
+    "        self.entries = entries\n",
+    "    \n",
+    "    def select(self, group):\n",
+    "        return self.entries if group == 'nbdev' else []\n",
+    "    \n",
+    "    def get(self, group, default=None):\n",
+    "        return self.entries if group == 'nbdev' else (default or [])\n",
+    "\n",
+    "# Create mock entry points\n",
+    "mock_eps = MockEntryPoints([BadEntryPoint(), GoodEntryPoint()])\n",
+    "\n",
+    "# Patch importlib.metadata.entry_points\n",
+    "with xpatch('importlib.metadata.entry_points', return_value=mock_eps):\n",
     "    entries, py_syms = _build_lookup_table()\n",
     "    \n",
     "    # Should only contain the good entry\n",


### PR DESCRIPTION
@jph00 I have constantly getting this warning in my nbdev projects for the last few months. Today is the day to fix it.

> The pkg_resources package is slated for removal as early as 2025-11-30. Refrain from using this package or pin to Setuptools<81.
  import pkg_resources,importlib


```
(sarvamai-dubbing) ➜  sarvamai-dubbing git:(main) ✗ nbdev_prepare
/Users/kurianbenoy/git/dubbing-repos/sarvamai-dubbing/.venv/lib/python3.12/site-packages/nbdev/doclinks.py:20: UserWarning: pkg_resources is deprecated as an API. See https://setuptools.pypa.io/en/latest/pkg_resources.html. The pkg_resources package is slated for removal as early as 2025-11-30. Refrain from using this package or pin to Setuptools<81.
  import pkg_resources,importlib
```

- Many thanks to you and @hamelsmu for building nbdev. I now maintain packages with 1M+ downloads all thanks to you. I hope you remeber me, as I was the kid, who got kicked off from fast.ai class :)