### PR TITLE
Update package build process and add 'build' to requirements

### DIFF
--- a/nbdev/release.py
+++ b/nbdev/release.py
@@ -316,7 +316,7 @@ def release_pypi(
 ):
     "Create and upload Python package to PyPI"
     _dir = get_config().lib_path.parent
-    system(f'cd {_dir}  && rm -rf dist build && python setup.py sdist bdist_wheel')
+    system(f'cd {_dir}  && rm -rf dist build && python -m build')
     system(f'twine upload --repository {repository} {_dir}/dist/*')
 
 # %% ../nbs/api/18_release.ipynb

--- a/nbs/api/18_release.ipynb
+++ b/nbs/api/18_release.ipynb
@@ -749,7 +749,7 @@
     "):\n",
     "    \"Create and upload Python package to PyPI\"\n",
     "    _dir = get_config().lib_path.parent\n",
-    "    system(f'cd {_dir}  && rm -rf dist build && python setup.py sdist bdist_wheel')\n",
+    "    system(f'cd {_dir}  && rm -rf dist build && python -m build')\n",
     "    system(f'twine upload --repository {repository} {_dir}/dist/*')"
    ]
   },

--- a/settings.ini
+++ b/settings.ini
@@ -15,7 +15,7 @@ language = English
 custom_sidebar = True
 license = apache2
 status = 5
-requirements = fastcore>=1.8.0 execnb>=0.1.12 astunparse ghapi>=1.0.3 watchdog asttokens setuptools
+requirements = fastcore>=1.8.0 execnb>=0.1.12 astunparse ghapi>=1.0.3 watchdog asttokens setuptools build
 pip_requirements = PyYAML
 conda_requirements = pyyaml
 conda_user = fastai


### PR DESCRIPTION
 Fixes the deprecation warning:

```
.../.venv/lib/python3.12/site-packages/setuptools/_distutils/cmd.py:90: SetuptoolsDeprecationWarning: setup.py install is deprecated.
!!

        ********************************************************************************
        Please avoid running ``setup.py`` directly.
        Instead, use pypa/build, pypa/installer or other
        standards-based tools.

        See https://blog.ganssle.io/articles/2021/10/setup-py-deprecated.html for details.
        ********************************************************************************

!!
```

 ## Changes
 - Replace `python setup.py sdist bdist_wheel` with `python -m build` in `release_pypi` function
 - Add `build` dependency to requirements

## Background
As explained in https://blog.ganssle.io/articles/2021/10/setup-py-deprecated.html, direct `setup.py` invocations are deprecated because they cannot bootstrap their own dependencies and setuptools is moving away from providing CLI functionality. The modern approach uses `python -m build` which properly handles build-time dependencies in isolated environments.