### PR TITLE
Use forkserver for tests on MacOS

### DIFF
--- a/nbdev/test.py
+++ b/nbdev/test.py
@@ -86,7 +86,7 @@ def nbdev_test(
 
     if n_workers is None: n_workers = 0 if len(files)==1 else min(num_cpus(), 8)
     if IN_NOTEBOOK: kw = {'method':'spawn'} if os.name=='nt' else {'method':'forkserver'}
-    else: kw = {}
+    else: kw = {'method':'forkserver'} if sys.platform=='darwin' else {}
     wd_pth = get_config().nbs_path
     with working_directory(wd_pth if (wd_pth and wd_pth.exists()) else os.getcwd()):
         results = parallel(test_nb, files, skip_flags=skip_flags, force_flags=force_flags, n_workers=n_workers,

--- a/nbs/api/12_test.ipynb
+++ b/nbs/api/12_test.ipynb
@@ -180,7 +180,7 @@
     "\n",
     "    if n_workers is None: n_workers = 0 if len(files)==1 else min(num_cpus(), 8)\n",
     "    if IN_NOTEBOOK: kw = {'method':'spawn'} if os.name=='nt' else {'method':'forkserver'}\n",
-    "    else: kw = {}\n",
+    "    else: kw = {'method':'forkserver'} if sys.platform=='darwin' else {}\n",
     "    wd_pth = get_config().nbs_path\n",
     "    with working_directory(wd_pth if (wd_pth and wd_pth.exists()) else os.getcwd()):\n",
     "        results = parallel(test_nb, files, skip_flags=skip_flags, force_flags=force_flags, n_workers=n_workers,\n",
@@ -261,13 +261,7 @@
    "source": []
   }
  ],
- "metadata": {
-  "kernelspec": {
-   "display_name": "python3",
-   "language": "python",
-   "name": "python3"
-  }
- },
+ "metadata": {},
  "nbformat": 4,
  "nbformat_minor": 5
 }


### PR DESCRIPTION
Fix `BrokenProcessPool` error on macOS by using `forkserver` method

Fixes #1256

## Problem
`nbdev_test` fails on macOS with `BrokenProcessPool` error due to Objective-C runtime fork-safety issues. Current workarounds require setting environment variables or using `--n_workers 0`.

## Solution
Use `forkserver` multiprocessing method on macOS when running outside notebooks. This avoids fork-safety issues by forking from a clean server process before problematic libraries are loaded.

## Changes
- Updated `nbdev_test` to use `{'method':'forkserver'}` on macOS (`sys.platform=='darwin'`) when not in notebooks
- Maintains existing behavior for other platforms