### PR TITLE
docs: Fix typo in TODO.md

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -5,5 +5,5 @@
   - pick header level for functions/methods
 - implement stuff from nbdev export2html, e.g.(?):
   - `remove_widget_state`
-- fastcore conversion scripts + instuctions
+- fastcore conversion scripts + instructions
 


### PR DESCRIPTION
Fixes a minor typo: 'instuctions' -> 'instructions'