### PR TITLE
Improve error message raised when exporting relative import in notebook.

### DIFF
--- a/nbdev/maker.py
+++ b/nbdev/maker.py
@@ -111,7 +111,7 @@ def make_code_cells(*ss): return dict2nb({'cells':L(ss).map(mk_cell)}).cells
 # %% ../nbs/api/02_maker.ipynb #a2546836
 def relative_import(name, fname, level=0):
     "Convert a module `name` to a name relative to `fname`"
-    assert not level
+    if level: raise ValueError(f"nbdev export does not support relative imports: module={name}, export_path={fname}")
     sname = name.replace('.','/')
     if not(os.path.commonpath([sname,fname])): return name
     rel = os.path.relpath(sname, fname)

--- a/nbs/api/02_maker.ipynb
+++ b/nbs/api/02_maker.ipynb
@@ -350,7 +350,7 @@
     "#| export\n",
     "def relative_import(name, fname, level=0):\n",
     "    \"Convert a module `name` to a name relative to `fname`\"\n",
-    "    assert not level\n",
+    "    if level: raise ValueError(f\"nbdev export does not support relative imports: module={name}, export_path={fname}\")\n",
     "    sname = name.replace('.','/')\n",
     "    if not(os.path.commonpath([sname,fname])): return name\n",
     "    rel = os.path.relpath(sname, fname)\n",
@@ -817,6 +817,9 @@
   }
  ],
  "metadata": {
+  "language_info": {
+   "name": "python"
+  },
   "solveit_dialog_mode": "learning",
   "solveit_ver": 2
  },

--- a/nbs/api/02_maker.ipynb
+++ b/nbs/api/02_maker.ipynb
@@ -817,9 +817,6 @@
   }
  ],
  "metadata": {
-  "language_info": {
-   "name": "python"
-  },
   "solveit_dialog_mode": "learning",
   "solveit_ver": 2
  },


### PR DESCRIPTION
Fixes https://github.com/AnswerDotAI/nbdev/issues/1589

Before this change, export failed with just `assert not level` when exporting with relative import, which did not explain the actual problem. This update tells the user that relative imports are not supported during export and includes the relevant context.

@jph00 