### PR TITLE
fixes #1594

### DIFF
--- a/nbdev/test.py
+++ b/nbdev/test.py
@@ -32,7 +32,7 @@ def test_nb(fn,  # file name of notebook to test
             verbose=False,  # stream stdout/stderr from cells to console?
             save=False):  # write outputs back to notebook on success?
     "Execute tests in notebook in `fn` except those with `skip_flags`"
-    faulthandler.register(signal.SIGINT, all_threads=True, chain=True)
+    faulthandler.register(signal.SIGINT, file=sys.__stderr__, all_threads=True, chain=True)
     if basepath: sys.path.insert(0, str(basepath))
     if not IN_NOTEBOOK: os.environ["IN_TEST"] = '1'
     flags=set(L(skip_flags)) - set(L(force_flags))

--- a/nbs/api/12_test.ipynb
+++ b/nbs/api/12_test.ipynb
@@ -62,7 +62,7 @@
     "            verbose=False,  # stream stdout/stderr from cells to console?\n",
     "            save=False):  # write outputs back to notebook on success?\n",
     "    \"Execute tests in notebook in `fn` except those with `skip_flags`\"\n",
-    "    faulthandler.register(signal.SIGINT, all_threads=True, chain=True)\n",
+    "    faulthandler.register(signal.SIGINT, file=sys.__stderr__, all_threads=True, chain=True)\n",
     "    if basepath: sys.path.insert(0, str(basepath))\n",
     "    if not IN_NOTEBOOK: os.environ[\"IN_TEST\"] = '1'\n",
     "    flags=set(L(skip_flags)) - set(L(force_flags))\n",


### PR DESCRIPTION
`nbdev-test` fails with the following error, because `faulthandler.register` by default uses `sys.stderr` and it gets changed in execnb ipykernel environment. This PR sets `file=sys.__stderr__` which is the source terminal.

```
(uvws) ~/aai-ws/nbdev (main ✔) nbdev-test
UnsupportedOperation in /Users/keremturgutlu/aai-ws/nbdev/nbs/api/12_test.ipynb:
===========================================================================

While Executing Cell #6:
Traceback (most recent call last):
  File "/Users/keremturgutlu/aai-ws/nbdev/nbdev/test.py", line 55, in test_nb
    k.run_all(nb, exc_stop=True, preproc=_no_eval, verbose=verbose)
  File "/Users/keremturgutlu/aai-ws/execnb/execnb/shell.py", line 252, in run_all
    if self.exc and exc_stop: raise self.exc from None
                              ^^^^^^^^^^^^^^^^^^^^^^^^
  File "/Users/keremturgutlu/aai-ws/.venv/lib/python3.12/site-packages/IPython/core/interactiveshell.py", line 3748, in run_code
    exec(code_obj, self.user_global_ns, self.user_ns)
  File "<ipython-input-1-a46277746112>", line 2, in <module>
    success,duration = test_nb(_nb, skip_flags=['notest'])
                       ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "<ipython-input-1-058ebeb728be>", line 11, in test_nb
    faulthandler.register(signal.SIGINT, all_threads=True, chain=True)
io.UnsupportedOperation: fileno
```