### PR TITLE
Fix linkify to handle list-form markdown outputs

### DIFF
--- a/nbdev/doclinks.py
+++ b/nbdev/doclinks.py
@@ -296,6 +296,7 @@ class NbdevLookup:
 
     def linkify(self, md):
         if md:
+            if isinstance(md,list): md = ''.join(md)
             in_fence=False
             lines = md.splitlines()
             for i,l in enumerate(lines):

--- a/nbs/api/05_doclinks.ipynb
+++ b/nbs/api/05_doclinks.ipynb
@@ -726,6 +726,7 @@
     "\n",
     "    def linkify(self, md):\n",
     "        if md:\n",
+    "            if isinstance(md,list): md = ''.join(md)\n",
     "            in_fence=False\n",
     "            lines = md.splitlines()\n",
     "            for i,l in enumerate(lines):\n",
@@ -1044,6 +1045,17 @@
     "    return `bar`\n",
     "```\"\"\"\n",
     "assert NbdevLookup().linkify(md) == md"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "f3a1b2c4",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Outputs read from disk may store markdown as a list of lines\n",
+    "test_eq(NbdevLookup().linkify(['a\\n','b']), 'a\\nb')"
    ]
   },
   {


### PR DESCRIPTION
## Summary

Fixes the docs build (`nbdev-docs` / `nbdev-proc-nbs`), currently broken on main: `NbdevLookup.linkify` assumes markdown is a string, but notebooks store multiline mime data as lists of lines per the nbformat convention, so `add_links` crashes with `AttributeError: 'list' object has no attribute 'splitlines'` on any notebook with a saved markdown output.

## Changes

- **Join list input in `linkify`**: `if isinstance(md,list): md = ''.join(md)` before splitting into lines. The write side re-splits on save, so round-tripping is unchanged.
- **Test**: `linkify` on a list of lines returns the joined, linkified string.

## Motivation

Recent fastcore releases write notebooks with nbformat-standard split lines (AnswerDotAI/fastcore#836), so cleaned notebooks now store `text/markdown` outputs as lists, which `linkify` had never seen before. This surfaced in PR CI (the docs build check runs on PRs, e.g. #1597) but reproduces on main directly with `nbdev-proc-nbs`.