### PR TITLE
fix patch_name IndexError when @patch_to uses cls= kwarg

### DIFF
--- a/nbdev/doclinks.py
+++ b/nbdev/doclinks.py
@@ -48,7 +48,7 @@ def patch_name(o):
     if nm=='patch': 
         a = o.args.args[0].annotation
         if isinstance(a, ast.BinOp): return _binop_leafs(a, o)
-    elif nm=='patch_to': a = d.args[0]
+    elif nm=='patch_to': a = d.args[0] if d.args else next(k.value for k in d.keywords if k.arg=='cls')
     else: return o.name
     return _sym_nm(a,o)
 

--- a/nbs/api/05_doclinks.ipynb
+++ b/nbs/api/05_doclinks.ipynb
@@ -100,7 +100,7 @@
     "    if nm=='patch': \n",
     "        a = o.args.args[0].annotation\n",
     "        if isinstance(a, ast.BinOp): return _binop_leafs(a, o)\n",
-    "    elif nm=='patch_to': a = d.args[0]\n",
+    "    elif nm=='patch_to': a = d.args[0] if d.args else next(k.value for k in d.keywords if k.arg=='cls')\n",
     "    else: return o.name\n",
     "    return _sym_nm(a,o)"
    ]
@@ -126,6 +126,16 @@
    "source": [
     "s = \"@patch_to(_T)\\ndef _g(self): ...\"\n",
     "test_eq('_T._g', _test_patch(s))"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "s = \"@patch_to(cls=_T)\\ndef _h(self): ...\"\n",
+    "test_eq('_T._h', _test_patch(s))"
    ]
   },
   {


### PR DESCRIPTION
`patch_name` assumes `@patch_to` always gets its class positionally, so
`d.args[0]` crashes when someone writes `@patch_to(cls=MyClass)` instead.

Fall back to `d.keywords` when `d.args` is empty. Added a test for the
keyword form alongside the existing positional one.

Closes #1596