### PR TITLE
Fix failing tests: add missing tempfile import in 04_export

### DIFF
--- a/nbs/api/04_export.ipynb
+++ b/nbs/api/04_export.ipynb
@@ -51,6 +51,7 @@
    "outputs": [],
    "source": [
     "#| hide\n",
+    "import warnings, tempfile\n",
     "from fastcore.test import *\n",
     "from pdb import set_trace\n",
     "from importlib import reload\n",
@@ -219,7 +220,6 @@
    "source": [
     "#| hide\n",
     "# a doc-only nb (title + `exportd` code, no default_exp) exports nothing, with no spurious warning\n",
-    "import warnings\n",
     "with tempfile.TemporaryDirectory() as d:\n",
     "    d = Path(d)\n",
     "    nb = dict2nb({'cells':[mk_cell('# T', 'markdown'), mk_cell('#| exportd\\nprint(1)')]})\n",


### PR DESCRIPTION
The test cell 
in 04_export used `tempfile.TemporaryDirectory()` but never imported `tempfile`, causing failures. 
Adds the import alongside `warnings` at the top of the hide block and removes the now-redundant 
duplicate `import warnings`.