### PR TITLE
Support post-release version bumps

### DIFF
--- a/nbdev/config.py
+++ b/nbdev/config.py
@@ -315,9 +315,15 @@ def set_version(path, version):
     fname.write_text(code)
 
 # %% ../nbs/api/01_config.ipynb #d00889e5
-def bump_version(v, part=2, unbump=False):
-    "Bump semver part `part` (0=major, 1=minor, 2=patch), counted from the right"
-    parts = (v or '0.0.0').split('.')
+def bump_version(v, part=None, unbump=False):
+    "Bump `.postN` by default when present, otherwise a semver part counted from the right"
+    v = v or '0.0.0'
+    post = re.fullmatch(r'(.*)\.post(\d+)', v)
+    if part is None and post:
+        n = max(0, int(post[2]) + (-1 if unbump else 1))
+        return f'{post[1]}.post{n}'
+    if part is None: part = 2
+    parts = (post[1] if post else v).split('.')
     parts += ['0'] * (3 - len(parts))
     idx = len(parts) - 3 + part
     parts[idx] = str(int(parts[idx]) + (-1 if unbump else 1))

--- a/nbdev/release.py
+++ b/nbdev/release.py
@@ -386,7 +386,7 @@ def release_both(
 # %% ../nbs/api/18_release.ipynb #c0f64b2c
 @call_parse
 def nbdev_bump_version(
-    part:int=2,  # Part of version to bump
+    part:int=None,  # Release part to bump; defaults to post when present, otherwise patch
     unbump:bool=False):  # Reduce version instead of increasing it
     "Increment version in __init__.py by one"
     cfg = get_config()

--- a/nbs/api/01_config.ipynb
+++ b/nbs/api/01_config.ipynb
@@ -807,9 +807,15 @@
    "outputs": [],
    "source": [
     "#| export\n",
-    "def bump_version(v, part=2, unbump=False):\n",
-    "    \"Bump semver part `part` (0=major, 1=minor, 2=patch), counted from the right\"\n",
-    "    parts = (v or '0.0.0').split('.')\n",
+    "def bump_version(v, part=None, unbump=False):\n",
+    "    \"Bump `.postN` by default when present, otherwise a semver part counted from the right\"\n",
+    "    v = v or '0.0.0'\n",
+    "    post = re.fullmatch(r'(.*)\\.post(\\d+)', v)\n",
+    "    if part is None and post:\n",
+    "        n = max(0, int(post[2]) + (-1 if unbump else 1))\n",
+    "        return f'{post[1]}.post{n}'\n",
+    "    if part is None: part = 2\n",
+    "    parts = (post[1] if post else v).split('.')\n",
     "    parts += ['0'] * (3 - len(parts))\n",
     "    idx = len(parts) - 3 + part\n",
     "    parts[idx] = str(int(parts[idx]) + (-1 if unbump else 1))\n",
@@ -844,7 +850,10 @@
     "test_eq(bump_version('1.2.3', part=2, unbump=True), '1.2.2')\n",
     "test_eq(bump_version('2026.05.27.2'), '2026.05.27.3')\n",
     "test_eq(bump_version('2026.05.27.2', part=1), '2026.05.28.0')\n",
-    "test_eq(bump_version('2026.05.27.2', part=0), '2026.6.0.0')"
+    "test_eq(bump_version('2026.05.27.2', part=0), '2026.6.0.0')\n",
+    "test_eq(bump_version('0.0.2026082005.post1'), '0.0.2026082005.post2')\n",
+    "test_eq(bump_version('0.0.2026082005.post2', unbump=True), '0.0.2026082005.post1')\n",
+    "test_eq(bump_version('0.0.2026082005.post1', part=2), '0.0.2026082006')"
    ]
   },
   {

--- a/nbs/api/18_release.ipynb
+++ b/nbs/api/18_release.ipynb
@@ -1094,7 +1094,9 @@
    "id": "9f1f82aa",
    "metadata": {},
    "source": [
-    "## Bump Version"
+    "## Bump Version\n",
+    "\n",
+    "By default, a post-release version increments `.postN`; other versions increment their patch component. Passing `--part` explicitly selects a release component and removes the post suffix."
    ]
   },
   {
@@ -1107,7 +1109,7 @@
     "#| export\n",
     "@call_parse\n",
     "def nbdev_bump_version(\n",
-    "    part:int=2,  # Part of version to bump\n",
+    "    part:int=None,  # Release part to bump; defaults to post when present, otherwise patch\n",
     "    unbump:bool=False):  # Reduce version instead of increasing it\n",
     "    \"Increment version in __init__.py by one\"\n",
     "    cfg = get_config()\n",


### PR DESCRIPTION
Make the default version bump increment `.postN` when the current version is a post release, while an explicit `--part` continues to select a release component and removes the post suffix.

The implementation, examples, tests, and CLI documentation live in the existing configuration and release notebook narratives under “Bump Version”.