### PR TITLE
Don't scaffold an empty package when `nbdev-export` exports nothing

### DIFF
--- a/nbdev/doclinks.py
+++ b/nbdev/doclinks.py
@@ -154,9 +154,10 @@ def nbdev_export(
         procs = [import_obj(p) for p in procs] if procs else None
         files = nbglob(path=path, as_path=True, **kwargs).sorted('name')
         for f in files: nb_export(f, procs=procs)
-        add_init(cfg.lib_path)
-        update_llms_txt()
-        _build_modidx()
+        if cfg.lib_path.exists():
+            add_init(cfg.lib_path)
+            update_llms_txt()
+            _build_modidx()
 
 # %% ../nbs/api/05_doclinks.ipynb #3134c22b
 typs = 'module','class','method','function'

--- a/nbs/api/05_doclinks.ipynb
+++ b/nbs/api/05_doclinks.ipynb
@@ -379,9 +379,10 @@
     "        procs = [import_obj(p) for p in procs] if procs else None\n",
     "        files = nbglob(path=path, as_path=True, **kwargs).sorted('name')\n",
     "        for f in files: nb_export(f, procs=procs)\n",
-    "        add_init(cfg.lib_path)\n",
-    "        update_llms_txt()\n",
-    "        _build_modidx()"
+    "        if cfg.lib_path.exists():\n",
+    "            add_init(cfg.lib_path)\n",
+    "            update_llms_txt()\n",
+    "            _build_modidx()"
    ]
   },
   {


### PR DESCRIPTION
`nbdev-export` ran `add_init`, `update_llms_txt`, and `_build_modidx` unconditionally. In a project whose notebooks export nothing and whose `lib_path` does not exist (for example a maturin repo with hand-written modules and docs-only notebooks), that created an empty package at the default lib path: `__init__.py` and a `_modidx.py` with no symbols.

The tail now runs only when `lib_path` exists. Any notebook that exports creates the directory, so exporting projects are unchanged.