### PR TITLE
`nbdev-test` takes its path as a positional argument

### DIFF
--- a/nbdev/test.py
+++ b/nbdev/test.py
@@ -123,7 +123,7 @@ def _keep_file(
     else: True
 
 # %% ../nbs/api/12_test.ipynb #f8cc6a61-a48e-4ab1-89a9-18316ca795d6
-@call_parse
+@call_parse(pos=['path'])
 @delegates(nbglob_cli)
 def nbdev_test(
     path:str=None,  # A notebook name or glob to test

--- a/nbs/api/12_test.ipynb
+++ b/nbs/api/12_test.ipynb
@@ -283,7 +283,7 @@
    "outputs": [],
    "source": [
     "#| export\n",
-    "@call_parse\n",
+    "@call_parse(pos=['path'])\n",
     "@delegates(nbglob_cli)\n",
     "def nbdev_test(\n",
     "    path:str=None,  # A notebook name or glob to test\n",
@@ -358,13 +358,13 @@
     "You can even run `nbdev-test` in non nbdev projects, for example, you can test an individual notebook like so:\n",
     "\n",
     "```\n",
-    "nbdev-test --path ../../tests/minimal.ipynb --do-print\n",
+    "nbdev-test ../../tests/minimal.ipynb --do-print\n",
     "```\n",
     "\n",
     "Or you can test an entire directory of notebooks filtered for only those that match a regular expression:\n",
     "\n",
     "```\n",
-    "nbdev-test --path ../../tests --file-re '.*test.ipynb' --do-print\n",
+    "nbdev-test ../../tests --file-re '.*test.ipynb' --do-print\n",
     "```"
    ]
   },

--- a/nbs/tutorials/modular_nbdev.ipynb
+++ b/nbs/tutorials/modular_nbdev.ipynb
@@ -123,13 +123,13 @@
     "You can test an individual notebook with the terminal command:\n",
     "\n",
     "```sh\n",
-    "nbdev-test --path notebook.ipynb\n",
+    "nbdev-test notebook.ipynb\n",
     "```\n",
     "\n",
     "...or a folder of notebooks:\n",
     "\n",
     "```sh\n",
-    "nbdev-test --path tests/\n",
+    "nbdev-test tests/\n",
     "```"
    ]
   },


### PR DESCRIPTION
`nbdev-test nbs/00_core.ipynb` now works: `path` is an optional positional
argument, matching pytest and friends. Bare `nbdev-test` still tests the
whole project, and the Python `nbdev_test(path=...)` signature is unchanged.

This replaces the `--path` flag, which is no longer accepted: scripts using
`nbdev-test --path ...` should drop the flag. The usage examples in the
`nbdev.test` docs and the modular nbdev tutorial use the new spelling.